### PR TITLE
Add null check to $privs to catch unelevated runs

### DIFF
--- a/Public/Invoke-AsCurrentUser.ps1
+++ b/Public/Invoke-AsCurrentUser.ps1
@@ -34,7 +34,7 @@ function Invoke-AsCurrentUser {
         return
     }
     $privs = whoami /priv /fo csv | ConvertFrom-Csv | Where-Object { $_.'Privilege Name' -eq 'SeDelegateSessionUserImpersonatePrivilege' }
-    if ($privs.State -eq "Disabled") {
+    if (!$privs -or $privs.State -eq "Disabled") {
         Write-Error -Message "Not running with correct privilege. You must run this script as system or have the SeDelegateSessionUserImpersonatePrivilege token."
         return
     }


### PR DESCRIPTION
If RunAsUser is run in an unelevated PowerShell instance, the filtered whoami returns null instead of a disabled state.