### PR TITLE
Add functionality to use Microsoft PowerShell Core (pwsh.exe)

### DIFF
--- a/Public/Invoke-AsCurrentUser.ps1
+++ b/Public/Invoke-AsCurrentUser.ps1
@@ -9,6 +9,8 @@ function Invoke-AsCurrentUser {
         [Parameter(Mandatory = $false)]
         [switch]$UseWindowsPowerShell,
         [Parameter(Mandatory = $false)]
+        [switch]$UseMicrosoftPowerShell,
+        [Parameter(Mandatory = $false)]
         [switch]$NonElevatedSession,
         [Parameter(Mandatory = $false)]
         [switch]$Visible,
@@ -31,6 +33,11 @@ function Invoke-AsCurrentUser {
     if ($OSLevel -lt 6.2) { $MaxLength = 8190 } else { $MaxLength = 32767 }
     if ($encodedcommand.length -gt $MaxLength -and $CacheToDisk -eq $false) {
         Write-Error -Message "The encoded script is longer than the command line parameter limit. Please execute the script with the -CacheToDisk option."
+        return
+    }
+    if ( $UseMicrosoftPowerShell -and -not (Test-Path -Path "$env:ProgramFiles\PowerShell\7\pwsh.exe"))
+    {
+        Write-Error -Message "Not able to find Microsoft PowerShell (pwsh.exe). Ensure that it is installed on this system"
         return
     }
     $privs = whoami /priv /fo csv | ConvertFrom-Csv | Where-Object { $_.'Privilege Name' -eq 'SeDelegateSessionUserImpersonatePrivilege' }


### PR DESCRIPTION
This addresses the items that are issue #15 

Added the switch -UseMicrosoftPowershell. When it is used the script will check if Microsoft PowerShell (aka PowerShell Core) is installed and then run the script block with that version. 

This is useful in cases where an RMM uses its own version of PowerShell, or only looks for Windows PowerShell, but feature are needed  from newer versions.